### PR TITLE
chore: Clarify cerbosctl is also installed in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Cerbos Setup Action
 
-A GitHub action to install [Cerbos](https://github.com/cerbos/cerbos) binaries for use in workflows.
+A GitHub action to install [Cerbos](https://github.com/cerbos/cerbos) binaries (`cerbos` and `cerbosctl`) for use in workflows.
 
 Cerbos helps you super-charge your authorization implementation by writing context-aware access control policies for your application resources. Find out more about Cerbos using the following resources:
 
@@ -13,6 +13,7 @@ Cerbos helps you super-charge your authorization implementation by writing conte
 
 If `version` is not specified or set to `latest`, the action will download the latest Cerbos release.
 
+### Setup `cerbos` and `cerbosctl` binaries
 ```yaml
 steps:
   - name: Setup Cerbos
@@ -20,6 +21,34 @@ steps:
     with:
       github_token: <github_token>
       version: latest
+```
+
+### Setup `cerbos` and `cerbosctl` binaries and show `cerbos` binary version
+```yaml
+steps:
+  - name: Setup Cerbos
+    uses: cerbos/cerbos-setup-action@v1
+    with:
+      github_token: <github_token>
+      version: latest
+  
+  - name: Show cerbos binary version
+    run: |
+      cerbos --version
+```
+
+### Setup `cerbos` and `cerbosctl` binaries and show `cerbosctl` binary version
+```yaml
+steps:
+  - name: Setup Cerbos
+    uses: cerbos/cerbos-setup-action@v1
+    with:
+      github_token: <github_token>
+      version: latest
+  
+  - name: Show cerbosctl binary version
+    run: |
+      cerbosctl version
 ```
 
 ## Development

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ steps:
       version: latest
 ```
 
-### Setup `cerbos` and `cerbosctl` binaries and show `cerbos` binary version
+### Setup `cerbos` and `cerbosctl` binaries and show their versions
 ```yaml
 steps:
   - name: Setup Cerbos
@@ -32,24 +32,10 @@ steps:
       github_token: <github_token>
       version: latest
   
-  - name: Show cerbos binary version
+  - name: Show versions
     run: |
       cerbos --version
-```
-
-### Setup `cerbos` and `cerbosctl` binaries and show `cerbosctl` binary version
-```yaml
-steps:
-  - name: Setup Cerbos
-    uses: cerbos/cerbos-setup-action@v1
-    with:
-      github_token: <github_token>
-      version: latest
-  
-  - name: Show cerbosctl binary version
-    run: |
       cerbosctl version
-```
 
 ## Development
 


### PR DESCRIPTION
Clarified that this action install both `cerbos` and `cerbosctl` binaries.
Basic examples also make sure this is not missed.
However, I did not add any other usage example demonstrating `cerbos-compile-action` or uploading some policies to a store due to it is being out of scope of this GitHub action. 
I think it'd better if we do it in its respective action(s), or in the Cerbos documentation.